### PR TITLE
More 1.5.0 updates, rerender

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - CONDA_PY=27
     - CONDA_PY=34
     - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "Ds5Q9PuuvUPzqrpNu0fckYDOCsD2BrrvihQajqObxTv9EmoyNIdFXpFFjGawGDpeoMKoQn7R+h5uq1+G8+F09s9MbYyTQaCd6Z67izOkazHlzu5TywOR2B0+YLfvW5RYJ9aEguoi5qfSZdNVVv+rcGpsAwfyUxJSO5oar8PHrWvqGt2xKG7zq7lIn9Oc+wYxgzsodbiIDakL664M22fT+oYUUkXYW2GKzUj/cq1nvGl6xY4ncStAslMhTmUriv6nMUlxYFkonjc8uhpYZgFOEgRGIRVXsNtqBDbJ7EMph7qLK2PcvpcBojOL+j0IDBvtSmAH4b2NGA7/ZqVi2zUA5OFT93EFsN8RV8VZXSmZ1tVV3fdUH//1oxrfEHBFqHSHnhiBk3EyW6OS76TU4+ioql2/ObTpJmoITEXtgcJayNAR93pLU7IOSRcMkuHCaFPn1zzsCfy7l+amtW7aZ/u8j55CxV7d3H6nWiqNpw2Scvk3x2t+LviJyZMvYYfdzNgfj6iqjMFmulW4ZpE43BjtIfE/bnXisyt8WGaGFHkj2oxjeNsTofYHPMy9+Gyhff80/jzYQmbSZLvL0RLLDCeN/abT2VkD5wtlSg+jF2Ss1kx0N7cPViI/9cEAvYr7eBc7yKIOJMqCFJ3hHiqbawgEjyKF/YD8FP8Qy14OI/X3Tnw="
@@ -25,9 +26,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ Summary: A command-line utility that creates projects from cookiecutters (projec
 
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/cookiecutter-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/cookiecutter-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/cookiecutter-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/cookiecutter-feedstock)
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/cookiecutter-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/cookiecutter-feedstock/branch/master)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/cookiecutter/badges/version.svg)](https://anaconda.org/conda-forge/cookiecutter)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/cookiecutter/badges/downloads.svg)](https://anaconda.org/conda-forge/cookiecutter)
+
 Installing cookiecutter
 =======================
 
@@ -32,7 +44,6 @@ It is possible to list all of the versions of `cookiecutter` available on your p
 ```
 conda search cookiecutter --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -68,18 +79,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/cookiecutter-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/cookiecutter-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/cookiecutter-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/cookiecutter-feedstock)
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/cookiecutter-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/cookiecutter-feedstock/branch/master)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/cookiecutter/badges/version.svg)](https://anaconda.org/conda-forge/cookiecutter)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/cookiecutter/badges/downloads.svg)](https://anaconda.org/conda-forge/cookiecutter)
 
 
 Updating cookiecutter-feedstock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,16 +4,11 @@
 
 environment:
 
-  CONDA_INSTALL_LOCN: "C:\\conda"
-
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script intepreter
   # See: http://stackoverflow.com/a/13751649/163740
   CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
 
-  # We set a default Python version for the miniconda that is to be installed. This can be
-  # overridden in the matrix definition where appropriate.
-  CONDA_PY: "27"
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -21,21 +16,35 @@ environment:
   matrix:
     - TARGET_ARCH: x86
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3
 
     - TARGET_ARCH: x64
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x86
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -56,14 +65,25 @@ install:
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
-    - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
-    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add our channels.
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --add channels conda-forge
+
+    # Add a hack to switch to `conda` version `4.1.12` before activating.
+    # This is required to handle a long path activation issue.
+    # Please see PR ( https://github.com/conda/conda/pull/3349 ).
+    - cmd: conda install --yes --quiet conda=4.1.12
+    - cmd: set "PATH=%OLDPATH%"
+    - cmd: set "OLDPATH="
+
+    # Actually activate `conda`.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,7 +41,7 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 3 case(s).
+# Embarking on 4 case(s).
     set -x
     export CONDA_PY=27
     set +x
@@ -56,6 +56,12 @@ source run_conda_forge_build_setup
 
     set -x
     export CONDA_PY=35
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,12 +13,10 @@ source:
   sha256: 553d00dcbdb6eed252ff15b5622ed98b2a22ffa96fc1b49717b4fbea32378526
 
 build:
-  number: 1
+  number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
   entry_points:
     - cookiecutter = cookiecutter.cli:main
-    # master has changed it's setup a bit as of 4a64e48... will have to fix
-    # - cookiecutter = cookiecutter.__main__:main
 
 requirements:
   build:
@@ -36,22 +34,25 @@ requirements:
 
 test:
   requires:
+    - freezegun
     - git
     - pytest
+    - pytest-catchlog
     - pytest-cov
-    - pytest-mock
+    - pytest-mock ==1.1
     - python
-    - freezegun
-  sourcefiles:
-    - *
+    - mercurial  # [py2k]
+  source_files:
+    - tests
   commands:
-    # Run basic commands.
     - cookiecutter --version
     - cookiecutter --help
-    - py.test --cov=cookiecutter -k "not _hg_ and not mercurial and not test_make_sure_path_exists and not pypackage_git"
+    - py.test --cov=cookiecutter -k "not test_make_sure_path_exists and not pypackage_git"
 
 about:
   home: https://github.com/{{ gh_org }}/{{ gh_repo }}
+  license_family: BSD
+  license_file: LICENSE
   license: BSD-3-Clause
   summary: >
             A command-line utility that creates projects from cookiecutters
@@ -61,5 +62,6 @@ about:
 extra:
   recipe-maintainers:
     - bollwyvl
+    - cadair
     - jakirkham
     - pydanny


### PR DESCRIPTION
Thanks for https://github.com/conda-forge/cookiecutter-feedstock/pull/8!

Here's some more:

- add you as a maintainer (feel free to remove!)
- add `license_file` and `_family` (mmmm metadata)
- add the new test dependency `pytest-catchlog` (i love it when they're already feedstocked!)
- rerender with conda-smithy `1.6.0` (look, python 3.6! don't know how that's going to go...)
- set the build back to `0`
- use `source_files` just for `tests` (love that)
