### PR TITLE
remove py36 selector

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
   script: python setup.py install --single-version-externally-managed --record=record.txt
   entry_points:
     - cookiecutter = cookiecutter.cli:main
-  skip: True  # [py36]
+  skip: True
 
 requirements:
   build:


### PR DESCRIPTION
Fixes the py36 selector... all the upstreams have py36 builds now, so this should be the last thing!